### PR TITLE
Always show "pick a court", even if no matches from address

### DIFF
--- a/docassemble/MACourtLocator/data/questions/court_locator.yml
+++ b/docassemble/MACourtLocator/data/questions/court_locator.yml
@@ -172,19 +172,31 @@ code: |
     all_matches = macourts.matching_courts(lookup_address, court_types=courts)
     
   filtered = combined_locations(all_matches)
----      
+---
+if: len(all_matches) == 0
+id: choose a court (none found)
+question: |
+  Pick a court
+subquestion: |
+  We didn't find any matching ${comma_and_list(courts)} court(s) that serve the address(es) you gave us.
+
+  Choose a court from the list below.
+fields:
+  - no label: court_choice
+    datatype: object
+    object labeler: |
+      lambda y: y.short_label()
+    choices: macourts
+---
+if: len(all_matches) > 0
 id: choose a court
 question: |
   Pick a court
 subquestion: |
-  % if len(all_matches) > 0:
   Below is a map of the ${comma_and_list(courts)} court(s) that serve the
   address(es) you gave us.
   
   ${map_of(combined_locations(all_matches))}
-  % else:
-  We didn't find any matching ${comma_and_list(courts)} court(s) that serve the address(es) you gave us.
-  % endif
 
   Choose a court from the list below.
 fields:


### PR DESCRIPTION
For some reason, if no courts are found from an address search, the "Pick a court" screen (id `choose a court`) doesn't show, even though it could set the `court_choice` variable being sought.

This results in a `There was a reference to a variable 'court_choice'` error screen shown to users.

We can achieve the desired behavior by splitting the "Pick a court" screen into one shown if there are no matches, and one shown if there is at least one match.

Fixes #3.